### PR TITLE
Pass MDAST markdown options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2841,6 +2841,112 @@
         }
       }
     },
+    "@mdx-js/mdx": {
+      "version": "2.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.0.0-next.9.tgz",
+      "integrity": "sha512-6i7iLIPApiCdvp4T6n3dI5IqDOvcNx4M3DUJ+AG6xj/NTssJcf5r3Gl4i3Q2tqJp0JAj6bWQ3IOLAefF18Y48g==",
+      "dev": true,
+      "requires": {
+        "@mdx-js/util": "2.0.0-next.1",
+        "astring": "^1.4.0",
+        "detab": "^2.0.0",
+        "estree-walker": "^2.0.0",
+        "hast-util-to-estree": "^1.1.0",
+        "mdast-util-to-hast": "^10.1.0",
+        "periscopic": "^2.0.0",
+        "rehype-minify-whitespace": "^4.0.0",
+        "remark-mdx": "2.0.0-next.9",
+        "remark-parse": "^9.0.0",
+        "remark-squeeze-paragraphs": "^4.0.0",
+        "unified": "^9.2.0",
+        "unist-builder": "^2.0.0"
+      },
+      "dependencies": {
+        "@mdx-js/util": {
+          "version": "2.0.0-next.1",
+          "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-2.0.0-next.1.tgz",
+          "integrity": "sha512-F36kWTFdFXrbNIsM77dhVwYZsZonUIKHkYyYgnuw1NWskBfEn1ET5B5Z5mm58ckKNf7SimchnxR9sKCCtH38WA==",
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
+        },
+        "mdast-util-definitions": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz",
+          "integrity": "sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit": "^2.0.0"
+          }
+        },
+        "mdast-util-to-hast": {
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
+          "integrity": "sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==",
+          "dev": true,
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "@types/unist": "^2.0.0",
+            "mdast-util-definitions": "^4.0.0",
+            "mdurl": "^1.0.0",
+            "unist-builder": "^2.0.0",
+            "unist-util-generated": "^1.0.0",
+            "unist-util-position": "^3.0.0",
+            "unist-util-visit": "^2.0.0"
+          }
+        },
+        "remark-mdx": {
+          "version": "2.0.0-next.9",
+          "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.0.0-next.9.tgz",
+          "integrity": "sha512-I5dCKP5VE18SMd5ycIeeEk8Hl6oaldUY6PIvjrfm65l7d0QRnLqknb62O2g3QEmOxCswcHTtwITtz6rfUIVs+A==",
+          "dev": true,
+          "requires": {
+            "mdast-util-mdx": "^0.1.1",
+            "micromark-extension-mdx": "^0.2.0",
+            "micromark-extension-mdxjs": "^0.3.0"
+          }
+        },
+        "remark-parse": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+          "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+          "dev": true,
+          "requires": {
+            "mdast-util-from-markdown": "^0.8.0"
+          }
+        },
+        "unified": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
+          "integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
+          "dev": true,
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        },
+        "unist-builder": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
+          "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
+          "dev": true
+        }
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -3126,6 +3232,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/estree": {
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -3167,6 +3279,15 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/mdast": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
+      "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "*"
       }
     },
     "@types/minimatch": {
@@ -3274,6 +3395,12 @@
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
       }
+    },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -3483,6 +3610,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astring": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.7.4.tgz",
+      "integrity": "sha512-WiVqDJV0AayUUH65FfUrbnBO4KD10854cyU49lK30+2n/lEkJDRqBKj/2fYGhZSD3uIt1H1VfW/pQtO07kR2Xg==",
       "dev": true
     },
     "async-each": {
@@ -5505,6 +5638,24 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "estree-util-attach-comments": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-1.0.0.tgz",
+      "integrity": "sha512-sL7dTwFGqzelPlB56lRZY1CC/yDxCe365WQpxNd49ispL40Yv8Tv4SmteGbvZeFwShOOVKfMlo4jrVvwoaMosA==",
+      "dev": true
+    },
+    "estree-util-is-identifier-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-1.1.0.tgz",
+      "integrity": "sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6860,11 +7011,53 @@
         }
       }
     },
+    "hast-util-embedded": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-1.0.6.tgz",
+      "integrity": "sha512-JQMW+TJe0UAIXZMjCJ4Wf6ayDV9Yv3PBDPsHD4ExBpAspJ6MOcCX+nzVF+UJVv7OqPcg852WEMSHQPoRA+FVSw==",
+      "dev": true,
+      "requires": {
+        "hast-util-is-element": "^1.1.0"
+      },
+      "dependencies": {
+        "hast-util-is-element": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
+          "integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==",
+          "dev": true
+        }
+      }
+    },
     "hast-util-is-element": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.3.tgz",
       "integrity": "sha512-C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA==",
       "dev": true
+    },
+    "hast-util-to-estree": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-1.3.3.tgz",
+      "integrity": "sha512-F5lYlB66lR795DwkPV+S1BV/liERgYqqlqipNBzc5epw7+Ui7isVOElvVlSU4gLeD+ZLm0VXHmGs0pH58GgVIg==",
+      "dev": true,
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "estree-util-attach-comments": "^1.0.0",
+        "estree-util-is-identifier-name": "^1.1.0",
+        "hast-util-whitespace": "^1.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0",
+        "style-to-object": "^0.3.0",
+        "unist-util-position": "^3.1.0",
+        "zwitch": "^1.0.0"
+      },
+      "dependencies": {
+        "unist-util-position": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
+          "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
+          "dev": true
+        }
+      }
     },
     "hast-util-to-html": {
       "version": "6.1.0",
@@ -7110,6 +7303,12 @@
         "validate-npm-package-license": "^3.0.1",
         "validate-npm-package-name": "^3.0.0"
       }
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
+      "dev": true
     },
     "inquirer": {
       "version": "6.5.2",
@@ -7445,6 +7644,15 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
+    },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
     },
     "is-regex": {
       "version": "1.1.1",
@@ -9527,6 +9735,12 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "dev": true
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -9617,6 +9831,15 @@
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
     },
+    "mdast-squeeze-paragraphs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-4.0.0.tgz",
+      "integrity": "sha512-zxdPn69hkQ1rm4J+2Cs2j6wDEv7O17TfXTJ33tl/+JPIoEmtV9t2ZzBM5LPHE8QlHsmVD8t3vPKCyY3oH+H8MQ==",
+      "dev": true,
+      "requires": {
+        "unist-util-remove": "^2.0.0"
+      }
+    },
     "mdast-util-definitions": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
@@ -9624,7 +9847,160 @@
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.0.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
+    },
+    "mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "dependencies": {
+        "parse-entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+          "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+          "dev": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        }
+      }
+    },
+    "mdast-util-mdx": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-0.1.1.tgz",
+      "integrity": "sha512-9nncdnHNYSb4HNxY3AwE6gU632jhbXsDGXe9PkkJoEawYWJ8tTwmEOHGlGa2TCRidtkd6FF5I8ogDU9pTDlQyA==",
+      "dev": true,
+      "requires": {
+        "mdast-util-mdx-expression": "~0.1.0",
+        "mdast-util-mdx-jsx": "~0.1.0",
+        "mdast-util-mdxjs-esm": "~0.1.0",
+        "mdast-util-to-markdown": "^0.6.1"
+      }
+    },
+    "mdast-util-mdx-expression": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-0.1.1.tgz",
+      "integrity": "sha512-SoO8y1B9NjMOYlNdwXMchuTVvqSTlUmXm1P5QvZNPv7OH7aa8qJV+3aA+vl1DHK9Vk1uZAlgwokjvDQhS6bINA==",
+      "dev": true,
+      "requires": {
+        "strip-indent": "^3.0.0"
+      }
+    },
+    "mdast-util-mdx-jsx": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-0.1.4.tgz",
+      "integrity": "sha512-67KOAvCmypBSpr+AJEAVQg1Obig5Wnguo4ETTxASe5WVP4TLt57bZjDX/9EW5sWYQsO4gPqLxkUOlypVn5rkhg==",
+      "dev": true,
+      "requires": {
+        "mdast-util-to-markdown": "^0.6.0",
+        "parse-entities": "^2.0.0",
+        "stringify-entities": "^3.1.0",
+        "unist-util-remove-position": "^3.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "dependencies": {
+        "parse-entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+          "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+          "dev": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "stringify-entities": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.1.0.tgz",
+          "integrity": "sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==",
+          "dev": true,
+          "requires": {
+            "character-entities-html4": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+          "dev": true
+        },
+        "unist-util-remove-position": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-3.0.0.tgz",
+          "integrity": "sha512-17kIOuolVuK16LMb9KyMJlqdfCtlfQY5FjY3Sdo9iC7F5wqdXhNjMq0PBvMpkVNNnAmHxXssUW+rZ9T2zbP0Rg==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit": "^2.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+          "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0",
+            "unist-util-visit-parents": "^3.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+          "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0"
+          }
+        }
+      }
+    },
+    "mdast-util-mdxjs-esm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-0.1.1.tgz",
+      "integrity": "sha512-kBiYeashz+nuhfv+712nc4THQhzXIH2gBFUDbuLxuDCqU/fZeg+9FAcdRBx9E13dkpk1p2Xwufzs3wsGJ+mISQ==",
+      "dev": true
     },
     "mdast-util-to-hast": {
       "version": "6.0.2",
@@ -9643,7 +10019,63 @@
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^1.1.0",
         "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
+    },
+    "mdast-util-to-markdown": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "dependencies": {
+        "parse-entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+          "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+          "dev": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        }
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true
     },
     "mdurl": {
       "version": "1.0.1",
@@ -9740,6 +10172,121 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
+    },
+    "micromark": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "parse-entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+          "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+          "dev": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        }
+      }
+    },
+    "micromark-extension-mdx": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx/-/micromark-extension-mdx-0.2.1.tgz",
+      "integrity": "sha512-J+nZegf1ExPz1Ft6shxu8M9WfRom1gwRIx6gpJK1SEEqKzY5LjOR1d/WHRtjwV4KoMXrL53+PoN7T1Rw1euJew==",
+      "dev": true,
+      "requires": {
+        "micromark": "~2.11.0",
+        "micromark-extension-mdx-expression": "~0.3.0",
+        "micromark-extension-mdx-jsx": "~0.3.0",
+        "micromark-extension-mdx-md": "~0.1.0"
+      }
+    },
+    "micromark-extension-mdx-expression": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-0.3.2.tgz",
+      "integrity": "sha512-Sh8YHLSAlbm/7TZkVKEC4wDcJE8XhVpZ9hUXBue1TcAicrrzs/oXu7PHH3NcyMemjGyMkiVS34Y0AHC5KG3y4A==",
+      "dev": true,
+      "requires": {
+        "micromark": "~2.11.0",
+        "vfile-message": "^2.0.0"
+      }
+    },
+    "micromark-extension-mdx-jsx": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-0.3.3.tgz",
+      "integrity": "sha512-kG3VwaJlzAPdtIVDznfDfBfNGMTIzsHqKpTmMlew/iPnUCDRNkX+48ElpaOzXAtK5axtpFKE3Hu3VBriZDnRTQ==",
+      "dev": true,
+      "requires": {
+        "estree-util-is-identifier-name": "^1.0.0",
+        "micromark": "~2.11.0",
+        "micromark-extension-mdx-expression": "^0.3.2",
+        "vfile-message": "^2.0.0"
+      }
+    },
+    "micromark-extension-mdx-md": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-0.1.1.tgz",
+      "integrity": "sha512-emlFQEyfx/2aPhwyEqeNDfKE6jPH1cvLTb5ANRo4qZBjaUObnzjLRdzK8RJ4Xc8+/dOmKN8TTRxFnOYF5/EAwQ==",
+      "dev": true
+    },
+    "micromark-extension-mdxjs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-0.3.0.tgz",
+      "integrity": "sha512-NQuiYA0lw+eFDtSG4+c7ao3RG9dM4P0Kx/sn8OLyPhxtIc6k+9n14k5VfLxRKfAxYRTo8c5PLZPaRNmslGWxJw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark": "~2.11.0",
+        "micromark-extension-mdx-expression": "~0.3.0",
+        "micromark-extension-mdx-jsx": "~0.3.0",
+        "micromark-extension-mdx-md": "~0.1.0",
+        "micromark-extension-mdxjs-esm": "~0.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
+          "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
+          "dev": true
+        }
+      }
+    },
+    "micromark-extension-mdxjs-esm": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-0.3.1.tgz",
+      "integrity": "sha512-tuLgcELrgY1a5tPxjk+MrI3BdYtwW67UaHZdzKiDYD8loNbxwIscfdagI6A2BKuAkrfeyHF6FW3B8KuDK3ZMXw==",
+      "dev": true,
+      "requires": {
+        "micromark": "~2.11.0",
+        "micromark-extension-mdx-expression": "^0.3.0",
+        "vfile-message": "^2.0.0"
+      }
     },
     "micromatch": {
       "version": "3.1.10",
@@ -10645,6 +11192,16 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "periscopic": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-2.0.3.tgz",
+      "integrity": "sha512-FuCZe61mWxQOJAQFEfmt9FjzebRlcpFz8sFPbyaCKtdusPkMEbA9ey0eARnRav5zAhmXznhaQkKGFAPn7X9NUw==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^2.0.2",
+        "is-reference": "^1.1.4"
+      }
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -11084,6 +11641,32 @@
         }
       }
     },
+    "rehype-minify-whitespace": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-4.0.5.tgz",
+      "integrity": "sha512-QC3Z+bZ5wbv+jGYQewpAAYhXhzuH/TVRx7z08rurBmh9AbG8Nu8oJnvs9LWj43Fd/C7UIhXoQ7Wddgt+ThWK5g==",
+      "dev": true,
+      "requires": {
+        "hast-util-embedded": "^1.0.0",
+        "hast-util-is-element": "^1.0.0",
+        "hast-util-whitespace": "^1.0.4",
+        "unist-util-is": "^4.0.0"
+      },
+      "dependencies": {
+        "hast-util-whitespace": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
+          "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==",
+          "dev": true
+        },
+        "unist-util-is": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+          "dev": true
+        }
+      }
+    },
     "rehype-stringify": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-6.0.1.tgz",
@@ -11124,6 +11707,15 @@
       "dev": true,
       "requires": {
         "mdast-util-to-hast": "^6.0.0"
+      }
+    },
+    "remark-squeeze-paragraphs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-4.0.0.tgz",
+      "integrity": "sha512-8qRqmL9F4nuLPIgl92XUuxI3pFxize+F1H0e/W3llTk0UsjJaj01+RrirkMw7P21RKe4X6goQhYRSvNWX+70Rw==",
+      "dev": true,
+      "requires": {
+        "mdast-squeeze-paragraphs": "^4.0.0"
       }
     },
     "remove-trailing-separator": {
@@ -11966,6 +12558,15 @@
         "through": "^2.3.4"
       }
     },
+    "style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "dev": true,
+      "requires": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -12438,6 +13039,23 @@
       "integrity": "sha512-tWvIbV8goayTjobxDIr4zVTyG+Q7ragMSMeKC3xnPl9xzIc0+she8mxXLM3JVNDDsfARPbCd3XdzkyLdo7fF3g==",
       "dev": true
     },
+    "unist-util-remove": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-2.1.0.tgz",
+      "integrity": "sha512-J8NYPyBm4baYLdCbjmf1bhPu45Cr1MWTm77qd9istEkzWpnN6O9tMsEbB2JhNnBCqGENRqEWomQ+He6au0B27Q==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^4.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+          "dev": true
+        }
+      }
+    },
     "unist-util-remove-position": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
@@ -12445,6 +13063,26 @@
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
     },
     "unist-util-stringify-position": {
@@ -12457,21 +13095,40 @@
       }
     },
     "unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
       "dev": true,
       "requires": {
-        "unist-util-visit-parents": "^2.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+          "dev": true
+        }
       }
     },
     "unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^3.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+          "dev": true
+        }
       }
     },
     "universal-user-agent": {
@@ -13007,6 +13664,12 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,15 +32,19 @@
     "@babel/cli": "^7.12.10",
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.10",
+    "@mdx-js/mdx": "^2.0.0-next.9",
     "babel-jest": "^26.6.3",
     "babel-plugin-add-module-exports": "^1.0.4",
     "jest": "^26.6.3",
     "lerna": "^3.22.1",
+    "mdast-util-mdx": "^0.1.1",
+    "micromark-extension-mdxjs": "^0.3.0",
     "rehype-stringify": "^6.0.1",
     "remark-parse": "^7.0.2",
     "remark-rehype": "^5.0.0",
     "rimraf": "^3.0.2",
-    "unified": "^8.4.2"
+    "unified": "^8.4.2",
+    "unist-util-visit": "^2.0.3"
   },
   "dependencies": {}
 }

--- a/packages/remark-deflist/README.md
+++ b/packages/remark-deflist/README.md
@@ -98,6 +98,36 @@ unified()
   .use(html)
 ```
 
+If you need to support (MDX)[https://mdxjs.com/] within the definition, you can
+pass in the following options:
+
+```javascript
+import unified from 'unified'
+import markdown from 'remark-parse'
+import html from 'rehype-stringify'
+import remark2rehype from 'remark-rehype'
+import deflist from 'remark-deflist'
+import mdxUtil from "mdast-util-mdx";
+import syntax from "micromark-extension-mdxjs";
+
+unified()
+  .use(markdown)
+  .use(deflist, {
+    fromMarkdownOptions: {
+      extensions: [syntax()],
+      mdastExtensions: [mdxUtil.fromMarkdown],
+    },
+    toMarkdownOptions: { extensions: [mdxUtil.toMarkdown] },
+  })
+  .use(remark2rehype)
+  .use(html)
+```
+
+Checkout the options you can pass for toMarkdownOptions in the
+[mdast-util-to-markdown api docs](https://github.com/syntax-tree/mdast-util-to-markdown#tomarkdowntree-options)
+and the options for fromMarkdownOptions in the [mdast-util-from-markdown api docs](https://github.com/syntax-tree/mdast-util-from-markdown#api).
+
+
 ## License
 
 [MIT](LICENSE.md) &copy; Alex Shaw

--- a/packages/remark-deflist/README.md
+++ b/packages/remark-deflist/README.md
@@ -98,29 +98,28 @@ unified()
   .use(html)
 ```
 
-If you need to support (MDX)[https://mdxjs.com/] within the definition, you can
-pass in the following options:
+If you are using (MDX)[https://mdxjs.com/] and want to support mdx syntax within the definition, you can pass in the following options:
 
 ```javascript
-import unified from 'unified'
-import markdown from 'remark-parse'
-import html from 'rehype-stringify'
-import remark2rehype from 'remark-rehype'
-import deflist from 'remark-deflist'
+import mdx from "@mdx-js/mdx";
+import deflist from "remark-deflist";
 import mdxUtil from "mdast-util-mdx";
 import syntax from "micromark-extension-mdxjs";
 
-unified()
-  .use(markdown)
-  .use(deflist, {
-    fromMarkdownOptions: {
-      extensions: [syntax()],
-      mdastExtensions: [mdxUtil.fromMarkdown],
-    },
-    toMarkdownOptions: { extensions: [mdxUtil.toMarkdown] },
-  })
-  .use(remark2rehype)
-  .use(html)
+mdx(fileName, {
+  remarkPlugins: [
+    [
+      deflist,
+      {
+        fromMarkdownOptions: {
+          extensions: [syntax()],
+          mdastExtensions: [mdxUtil.fromMarkdown],
+        },
+        toMarkdownOptions: { extensions: [mdxUtil.toMarkdown] },
+      },
+    ],
+  ],
+});
 ```
 
 Checkout the options you can pass for toMarkdownOptions in the

--- a/packages/remark-deflist/src/__snapshots__/index.spec.js.snap
+++ b/packages/remark-deflist/src/__snapshots__/index.spec.js.snap
@@ -38,13 +38,13 @@ export default MDXContent;
 "
 `;
 
-exports[`remark-deflist with an mdx parser should parse a definition list with another plugin syntax 1`] = `
+exports[`remark-deflist with an mdx parser should parse a definition list with another remark plugin's syntax 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
 /* @jsxFrag mdx.Fragment */
 const MDXLayout = \\"wrapper\\";
 function MDXContent({components, ...props}) {
-  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Definition List 1\\"}</dt><dd parentName=\\"dl\\">{\\"Definition^1, H\\"}<sub parentName=\\"dd\\">{\\"2\\"}</sub>{\\"0\\"}</dd></dl></MDXLayout>;
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Definition List 1\\"}</dt><dd parentName=\\"dl\\">{\\"Definition\\"}<sup parentName=\\"dd\\">{\\"1\\"}</sup>{\\", H\\"}<sub parentName=\\"dd\\">{\\"2\\"}</sub>{\\"0\\"}</dd></dl></MDXLayout>;
 }
 MDXContent.isMDXComponent = true;
 export default MDXContent;
@@ -58,19 +58,6 @@ exports[`remark-deflist with an mdx parser should parse a definition list with c
 const MDXLayout = \\"wrapper\\";
 function MDXContent({components, ...props}) {
   return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Term 1\\"}</dt><dd parentName=\\"dl\\">{\\"Definition\\\\nwith continuation.\\"}</dd></dl></MDXLayout>;
-}
-MDXContent.isMDXComponent = true;
-export default MDXContent;
-"
-`;
-
-exports[`remark-deflist with an mdx parser should parse a definition list with inline html 1`] = `
-"/* @jsxRuntime classic */
-/* @jsx mdx */
-/* @jsxFrag mdx.Fragment */
-const MDXLayout = \\"wrapper\\";
-function MDXContent({components, ...props}) {
-  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Cat\\"}</dt><dd parentName=\\"dl\\">{\\"Definition \\"}<b parentName=\\"dd\\">{2 + 5}</b></dd></dl></MDXLayout>;
 }
 MDXContent.isMDXComponent = true;
 export default MDXContent;

--- a/packages/remark-deflist/src/__snapshots__/index.spec.js.snap
+++ b/packages/remark-deflist/src/__snapshots__/index.spec.js.snap
@@ -1,26 +1,169 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`remark-deflist should parse a basic definition list 1`] = `"<dl><dt>Term 1</dt><dd>Definition 1</dd></dl>"`;
+exports[`remark-deflist with a standard parser should parse a basic definition list 1`] = `"<dl><dt>Term 1</dt><dd>Definition 1</dd></dl>"`;
 
-exports[`remark-deflist should parse a definition list with continuation 1`] = `
+exports[`remark-deflist with a standard parser should parse a definition list with continuation 1`] = `
 "<dl><dt>Term 1</dt><dd>Definition
 with continuation.</dd></dl>"
 `;
 
-exports[`remark-deflist should parse a definition list with inline markup 1`] = `"<dl><dt>Term <em>1</em></dt><dd>Definition <strong>1</strong></dd></dl>"`;
+exports[`remark-deflist with a standard parser should parse a definition list with inline markup 1`] = `"<dl><dt>Term <em>1</em></dt><dd>Definition <strong>1</strong></dd></dl>"`;
 
-exports[`remark-deflist should parse a definition list with lazy continuation 1`] = `
+exports[`remark-deflist with a standard parser should parse a definition list with lazy continuation 1`] = `
 "<dl><dt>Term 1</dt><dd>Definition
 with lazy continuation.</dd></dl>"
 `;
 
-exports[`remark-deflist should parse a definition list with multiple descriptions (#9) 1`] = `"<dl><dt>Multiple descriptions</dt><dd>Description <strong>1</strong></dd><dd>Description 2</dd></dl>"`;
+exports[`remark-deflist with a standard parser should parse a definition list with multiple descriptions (#9) 1`] = `"<dl><dt>Multiple descriptions</dt><dd>Description <strong>1</strong></dd><dd>Description 2</dd></dl>"`;
 
-exports[`remark-deflist should parse a definition list with no space between the term and the descriptions (#7) 1`] = `"<dl><dt>Term <strong>1</strong></dt><dd>Definition <strong>bold</strong> 1</dd><dd>Definition 2</dd></dl>"`;
+exports[`remark-deflist with a standard parser should parse a definition list with no space between the term and the descriptions (#7) 1`] = `"<dl><dt>Term <strong>1</strong></dt><dd>Definition <strong>bold</strong> 1</dd><dd>Definition 2</dd></dl>"`;
 
-exports[`remark-deflist should parse a document with other elements 1`] = `
+exports[`remark-deflist with a standard parser should parse a document with other elements 1`] = `
 "<dl><dt>Definition List</dt><dd>Definition 1</dd></dl>
 <p>This paragraph follows the definition list.</p>"
 `;
 
-exports[`remark-deflist should parse a document with several subsequent definition lists (#10) 1`] = `"<dl><dt>Definition List 1</dt><dd>Description 1</dd><dt>Definition List 2</dt><dd>Description 1</dd><dt>Definition List 3</dt><dd>Description 1</dd></dl>"`;
+exports[`remark-deflist with a standard parser should parse a document with several subsequent definition lists (#10) 1`] = `"<dl><dt>Definition List 1</dt><dd>Description 1</dd><dt>Definition List 2</dt><dd>Description 1</dd><dt>Definition List 3</dt><dd>Description 1</dd></dl>"`;
+
+exports[`remark-deflist with an mdx parser should parse a basic definition list 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Term 1\\"}</dt><dd parentName=\\"dl\\">{\\"Definition 1\\"}</dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a definition list with another plugin syntax 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Definition List 1\\"}</dt><dd parentName=\\"dl\\">{\\"Definition^1, H\\"}<sub parentName=\\"dd\\">{\\"2\\"}</sub>{\\"0\\"}</dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a definition list with continuation 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Term 1\\"}</dt><dd parentName=\\"dl\\">{\\"Definition\\\\nwith continuation.\\"}</dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a definition list with inline html 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Cat\\"}</dt><dd parentName=\\"dl\\">{\\"Definition \\"}<b parentName=\\"dd\\">{2 + 5}</b></dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a definition list with inline markup 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Term \\"}<em parentName=\\"dt\\">{\\"1\\"}</em></dt><dd parentName=\\"dl\\">{\\"Definition \\"}<strong parentName=\\"dd\\">{\\"1\\"}</strong></dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a definition list with jsx 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Definition List 1\\"}</dt><dd parentName=\\"dl\\">{\\"Definition \\"}<b parentName=\\"dd\\">{2 + 5}</b></dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a definition list with lazy continuation 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Term 1\\"}</dt><dd parentName=\\"dl\\">{\\"Definition\\\\nwith lazy continuation.\\"}</dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a definition list with multiple descriptions (#9) 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Multiple descriptions\\"}</dt><dd parentName=\\"dl\\">{\\"Description \\"}<strong parentName=\\"dd\\">{\\"1\\"}</strong></dd><dd parentName=\\"dl\\">{\\"Description 2\\"}</dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a definition list with no space between the term and the descriptions (#7) 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Term \\"}<strong parentName=\\"dt\\">{\\"1\\"}</strong></dt><dd parentName=\\"dl\\">{\\"Definition \\"}<strong parentName=\\"dd\\">{\\"bold\\"}</strong>{\\" 1\\"}</dd><dd parentName=\\"dl\\">{\\"Definition 2\\"}</dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a document with other elements 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Definition List\\"}</dt><dd parentName=\\"dl\\">{\\"Definition 1\\"}</dd></dl><p>{\\"This paragraph follows the definition list.\\"}</p></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;
+
+exports[`remark-deflist with an mdx parser should parse a document with several subsequent definition lists (#10) 1`] = `
+"/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+const MDXLayout = \\"wrapper\\";
+function MDXContent({components, ...props}) {
+  return <MDXLayout components={components} {...props}><dl><dt parentName=\\"dl\\">{\\"Definition List 1\\"}</dt><dd parentName=\\"dl\\">{\\"Description 1\\"}</dd><dt parentName=\\"dl\\">{\\"Definition List 2\\"}</dt><dd parentName=\\"dl\\">{\\"Description 1\\"}</dd><dt parentName=\\"dl\\">{\\"Definition List 3\\"}</dt><dd parentName=\\"dl\\">{\\"Description 1\\"}</dd></dl></MDXLayout>;
+}
+MDXContent.isMDXComponent = true;
+export default MDXContent;
+"
+`;

--- a/packages/remark-deflist/src/index.spec.js
+++ b/packages/remark-deflist/src/index.spec.js
@@ -9,11 +9,7 @@ import mdxUtil from "mdast-util-mdx";
 import syntax from "micromark-extension-mdxjs";
 import remarkSuperSub from "../../remark-supersub/src";
 
-const strip = ([str]) => {
-  const stripped = str.replace(/\n {6}/g, "\n").replace(/\n {4}$/, "");
-  console.log(stripped);
-  return stripped;
-};
+const strip = ([str]) => str.replace(/\n {6}/g, "\n").replace(/\n {4}$/, "");
 
 const parse = (str) =>
   unified()
@@ -22,7 +18,7 @@ const parse = (str) =>
     .use(remark2rehype)
     .use(html)
     .process(str)
-    .then((data) => data.toString());
+    .then(data => data.toString());
 
 const mdxParse = (str) =>
   mdx(str, {

--- a/packages/remark-deflist/src/index.spec.js
+++ b/packages/remark-deflist/src/index.spec.js
@@ -1,85 +1,113 @@
 /* eslint-env jest */
-import deflist from './index'
-import html from 'rehype-stringify'
-import markdown from 'remark-parse'
-import remark2rehype from 'remark-rehype'
-import unified from 'unified'
+import deflist from "./index";
+import html from "rehype-stringify";
+import markdown from "remark-parse";
+import remark2rehype from "remark-rehype";
+import unified from "unified";
+import mdx from "@mdx-js/mdx";
+import mdxUtil from "mdast-util-mdx";
+import syntax from "micromark-extension-mdxjs";
+import remarkSuperSub from "../../remark-supersub/src";
 
-const strip = ([str]) => str.replace(/\n {6}/g, '\n').replace(/\n {4}$/, '')
+const strip = ([str]) => {
+  const stripped = str.replace(/\n {6}/g, "\n").replace(/\n {4}$/, "");
+  console.log(stripped);
+  return stripped;
+};
 
-const parse = str =>
+const parse = (str) =>
   unified()
     .use(markdown)
     .use(deflist)
     .use(remark2rehype)
     .use(html)
-    .process(str)
-    .then(data => data.toString())
+    .process(str, function (err, file) {
+      if (err) throw err;
+      console.log(String(file));
+    })
+    .then((data) => data.toString());
+
+const mdxParse = (str) =>
+  mdx(str, {
+    remarkPlugins: [
+      [
+        deflist,
+        {
+          fromMarkdownOptions: {
+            extensions: [syntax()],
+            mdastExtensions: [mdxUtil.fromMarkdown],
+          },
+          toMarkdownOptions: { extensions: [mdxUtil.toMarkdown] },
+        },
+      ],
+      remarkSuperSub,
+    ],
+  }).then((data) => data.toString());
 
 const tests = [
   [
-    'basic definition list',
+    "basic definition list",
     strip`
       Term 1
 
       : Definition 1
-    `
+    `,
   ],
   [
-    'definition list with inline markup',
+    "definition list with inline markup",
     strip`
       Term *1*
 
       : Definition **1**
-    `
+    `,
   ],
   [
-    'document with other elements',
+    "document with other elements",
     strip`
       Definition List
 
       : Definition 1
 
       This paragraph follows the definition list.
-    `
+    `,
   ],
   [
-    'definition list with continuation',
+    "definition list with continuation",
     strip`
       Term 1
 
       : Definition
         with continuation.
-    `
+    `,
   ],
   [
-    'definition list with lazy continuation',
+    "definition list with lazy continuation",
     strip`
       Term 1
 
       : Definition
       with lazy continuation.
-    `
+    `,
   ],
   [
-    'definition list with no space between the term and the descriptions (#7)',
+    "definition list with no space between the term and the descriptions (#7)",
     strip`
       Term **1**
       : Definition **bold** 1
       : Definition 2
-    `
+    `,
   ],
   [
-    'definition list with multiple descriptions (#9)',
+    "definition list with multiple descriptions (#9)",
     strip`
       Multiple descriptions
 
       : Description **1**
       : Description 2
-    `
+    `,
   ],
   [
-    'document with several subsequent definition lists (#10)',
+    "document with several subsequent definition lists (#10)",
     strip`
       Definition List 1
 
@@ -92,12 +120,40 @@ const tests = [
       Definition List 3
 
       : Description 1
-    `
-  ]
-]
+    `,
+  ],
+];
 
-describe.each(tests)('remark-deflist', (name, source) => {
-  it(`should parse a ${name}`, () => {
-    return expect(parse(source)).resolves.toMatchSnapshot()
-  })
-})
+const mdxTests = [
+  ...tests,
+  [
+    "definition list with jsx",
+    strip`
+      Definition List 1
+
+      : Definition <b>{2 + 5}</b>
+    `,
+  ],
+  [
+    "definition list with another remark plugin's syntax",
+    strip`
+      Definition List 1
+
+      : Definition^1^, H~2~0
+    `,
+  ],
+];
+
+describe("remark-deflist", () => {
+  describe.skip.each(tests)("with a standard parser", (name, source) => {
+    it(`should parse a ${name}`, () => {
+      return expect(parse(source)).resolves.toMatchSnapshot();
+    });
+  });
+
+  describe.each(mdxTests)("with an mdx parser", (name, source) => {
+    it(`should parse a ${name}`, () => {
+      return expect(mdxParse(source)).resolves.toMatchSnapshot();
+    });
+  });
+});

--- a/packages/remark-deflist/src/index.spec.js
+++ b/packages/remark-deflist/src/index.spec.js
@@ -21,10 +21,7 @@ const parse = (str) =>
     .use(deflist)
     .use(remark2rehype)
     .use(html)
-    .process(str, function (err, file) {
-      if (err) throw err;
-      console.log(String(file));
-    })
+    .process(str)
     .then((data) => data.toString());
 
 const mdxParse = (str) =>


### PR DESCRIPTION
I was using `remark-deflist` with MDX and started to get some errors (namely that `mdxSpanExpression` didn't exist!). I saw in the docs for [mdast-util-mdx-jsx](https://github.com/syntax-tree/mdast-util-mdx-jsx#use) that the key to fixing it was some options.

In sleuthing this out, I saw that there were [two](https://github.com/Symbitic/remark-plugins/issues/13) [other](https://github.com/Symbitic/remark-plugins/issues/12) issues that I think would be fixed by contributing this back!

I debated between just adding these mdx settings directly or passing them as options to remark-deflist. I decided upon utilizing options (and adding some docs on what options to pass in) for the sake of flexibility.

Quick note: I had prettier turned on and it got aggressive. Let me know if you want to try the changes again without the prettier changes but I think consistent syntax isn't bad :shrug:. The main difference within `packages/remark-deflist/src/index.js` is the passing around of options.toMarkdownOptions and options.fromMarkdownOptions.